### PR TITLE
Covering feature request of @mboehm21 #10020

### DIFF
--- a/themes/obraun.zsh-theme
+++ b/themes/obraun.zsh-theme
@@ -2,12 +2,9 @@ if [ "$USERNAME" = "root" ]; then CARETCOLOR="red"; else CARETCOLOR="blue"; fi
 
 local return_code="%(?..%{$fg[red]%}%? ↵%{$reset_color%})"
 
-now=$(date +"%T")
-
-PROMPT='%{$fg[green]%}[$now]%{$reset_color%} %{$fg_no_bold[cyan]%}%n %{${fg_bold[blue]}%}::%{$reset_color%} %{$fg[yellow]%}%m%{$reset_color%} %{$fg_no_bold[magenta]%} ➜ %{$reset_color%} %{${fg[green]}%}%3~ $(git_prompt_info)%{${fg_bold[$CARETCOLOR]}%}»%{${reset_color}%} '
+ROMPT='%{$fg[green]%}%D{%H:%M:%S}%{$reset_color%} %{$fg_no_bold[cyan]%}%n %{${fg_bold[blue]}%}::%{$reset_color%} %{$fg[yellow]%}%m%{$reset_color%} %{$fg_no_bold[magenta]%} ➜ %{$reset_color%} %{${fg[green]}%}%3~ $(git_prompt_info)%{${fg_bold[$CARETCOLOR]}%}»%{${reset_color}%} '
 
 RPS1="${return_code}"
 
 ZSH_THEME_GIT_PROMPT_PREFIX="%{$fg[red]%}‹"
 ZSH_THEME_GIT_PROMPT_SUFFIX="› %{$reset_color%}"
-


### PR DESCRIPTION
The length of the prompt differs by one char dependent on CURRENT TIME:
Was:
```
[8:42:20] mboehm21 :: dws-mboehm21  ➜  ~ » 
[10:42:20] mboehm21 :: dws-mboehm21  ➜  ~ » 
```
Need ( feature request ):
```
[08:42:20] mboehm21 :: dws-mboehm21  ➜  ~ » 
[10:42:20] mboehm21 :: dws-mboehm21  ➜  ~ » 
```
Added latest fixes by  @mcornella using `%D{%H:%M:%S}` structure instead  my fix as `now=$(date +"%T")` and `[$now] `

## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

line 5, last 11 symbols
ROMPT='%{$fg[green]%}%D{%H:%M:%S}

## Other comments:

> Original issue #10020
> Is your feature request related to a particular plugin or theme? If so, specify it.
> obraun
> 
> Is your feature request related to a problem? Please describe.
> 
> The length of the prompt differs by one char dependent on current time:
> 
> ```
> [8:42:20] mboehm21 :: dws-mboehm21  ➜  ~ » 
> [10:42:20] mboehm21 :: dws-mboehm21  ➜  ~ » 
> ```
> 
> Describe the solution you'd like
> 
> It would be better when the hour would be displayed as two digits all the time:
> ```
> 
> [08:42:20] mboehm21 :: dws-mboehm21  ➜  ~ » 
> [10:42:20] mboehm21 :: dws-mboehm21  ➜  ~ » 
> ```

...
